### PR TITLE
Use newer virtualenv

### DIFF
--- a/install_rally.sh
+++ b/install_rally.sh
@@ -32,7 +32,8 @@ PYTHON2=$(which python || true)
 PYTHON3=$(which python3 || true)
 PYTHON=${PYTHON2:-$PYTHON3}
 BASE_PIP_URL=${BASE_PIP_URL:-"https://pypi.python.org/simple"}
-VIRTUALENV_191_URL="https://raw.github.com/pypa/virtualenv/1.9.1/virtualenv.py"
+VIRTUALENV_VERSION="15.1.0"
+VIRTUALENV_URL="https://raw.github.com/pypa/virtualenv/$VIRTUALENV_VERSION/virtualenv.py"
 
 RALLY_GIT_URL="https://git.openstack.org/openstack/rally"
 RALLY_GIT_BRANCH="master"
@@ -419,23 +420,24 @@ __EOF__
     fi
 
     # Use the latest virtualenv that can use `.tar.gz` files
-    VIRTUALENV_DST="$DESTDIR/virtualenv-191.py"
+    VIRTUALENV_DST="$DESTDIR/virtualenv-$VIRTUALENV_VERSION.py"
     mkdir -p "$DESTDIR"
-    download "$VIRTUALENV_DST" "$VIRTUALENV_191_URL"
-    "$PYTHON" "$VIRTUALENV_DST" $VERBOSE -p "$PYTHON" "$DESTDIR"
+    download "$VIRTUALENV_DST" "$VIRTUALENV_URL"
+    "$PYTHON" "$VIRTUALENV_DST" $VERBOSE --no-setuptools --no-pip --no-wheel \
+        -p "$PYTHON" "$DESTDIR"
 
     . "$DESTDIR"/bin/activate
 
-    # Setuptools>=0.8 is required to support "wheel" format, otherwise
-    # pip will fail with an error. To be sure, just run upgrade to the
-    # recent version of setuptools
-    download - https://bootstrap.pypa.io/ez_setup.py | python - --insecure\
-        || die ${EX_SOFTWARE}\
-            "Failed to install the latest version of Python 'setuptools'" <<__EOF__
+    local getpip="$DESTDIR/get-pip.py"
+    download - "$getpip" https://bootstrap.pypa.io/get-pip.py | python -\
+        || die $EX_PROTOCOL \
+        "Error while installing python-pip from external source." <<__EOF__
 
-The required Python package setuptools could not be installed.
+The required Python package pip could not be installed.
 
 __EOF__
+
+    pip install setuptools wheel
 }
 
 setup_rally_configuration () {


### PR DESCRIPTION
Backport changes from upstream to use a newer virtualenv to prevent errors when installing setuptools with pip.

```
$ ./install_rally.sh -d /tmp/rally
The following software packages need to be installed
in order for Rally to work:  python-devel

There is a small chance that the required software
is actually installed though we failed to detect it,
so you may choose to proceed with Rally installation
anyway.  Be warned however, that continuing is very
likely to fail!

Proceed with installation anyway? [yN] y
Proceeding with installation at your request... keep fingers crossed!
Installing Rally virtualenv in directory '/tmp/rally' ...
2018-02-07 12:31:25 URL:https://raw.githubusercontent.com/pypa/virtualenv/1.9.1/virtualenv.py [115013] -> "/tmp/rally/virtualenv-191.py" [1]
Already using interpreter /usr/bin/python
New python executable in /tmp/rally/bin/python
Installing setuptools.....................
  Complete output from command /tmp/rally/bin/python -c "#!python
\"\"\"Bootstra...sys.argv[1:])






" --always-copy -U setuptools:
  Downloading http://pypi.python.org/packages/2.7/s/setuptools/setuptools-0.6c11-py2.7.egg
Traceback (most recent call last):
  File "<string>", line 278, in <module>
  File "<string>", line 210, in main
  File "<string>", line 158, in download_setuptools
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 556, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 403: SSL is required
----------------------------------------
...Installing setuptools...done.
Traceback (most recent call last):
  File "/tmp/rally/virtualenv-191.py", line 2577, in <module>
    main()
  File "/tmp/rally/virtualenv-191.py", line 979, in main
    no_pip=options.no_pip)
  File "/tmp/rally/virtualenv-191.py", line 1091, in create_environment
    search_dirs=search_dirs, never_download=never_download)
  File "/tmp/rally/virtualenv-191.py", line 611, in install_setuptools
    search_dirs=search_dirs, never_download=never_download)
  File "/tmp/rally/virtualenv-191.py", line 583, in _install_req
    cwd=cwd)
  File "/tmp/rally/virtualenv-191.py", line 1057, in call_subprocess
    % (cmd_desc, proc.returncode))
OSError: Command /tmp/rally/bin/python -c "#!python
\"\"\"Bootstra...sys.argv[1:])






" --always-copy -U setuptools failed with error code 1
./install_rally.sh: line 427: /tmp/rally/bin/activate: No such file or directory
2018-02-07 12:31:26 URL:https://bootstrap.pypa.io/ez_setup.py [12537/12537] -> "-" [1]
ez_setup.py is deprecated and when using it setuptools will be pinned to 33.1.1 since it's the last version that supports setuptools self upgrade/installation, check https://github.com/pypa/setuptools/issues/581 for more info; use pip to install setuptools
Downloading https://pypi.io/packages/source/s/setuptools/setuptools-33.1.1.zip
Extracting in /tmp/tmpnt7f4Q
Now working in /tmp/tmpnt7f4Q/setuptools-33.1.1
Installing Setuptools
running install
error: can't create or remove files in install directory

The following error occurred while trying to add or remove files in the
installation directory:

    [Errno 13] Permission denied: '/usr/lib/python2.7/site-packages/test-easy-install-29481.write-test'

The installation directory you specified (via --install-dir, --prefix, or
the distutils default setting) was:

    /usr/lib/python2.7/site-packages/

Perhaps your account does not have write access to this directory?  If the
installation directory is a system-owned directory, you may need to sign in
as the administrator or "root" account.  If you do not have administrative
access to this machine, you may wish to choose a different installation
directory, preferably one that is listed in your PYTHONPATH environment
variable.

For information on other options, you may wish to consult the
documentation at:

  https://setuptools.readthedocs.io/en/latest/easy_install.html

Please make the appropriate changes for your system and try again.

Something went wrong during the installation.
See the error message above.
==========================================================
install_rally.sh: ERROR: Failed to install the latest version of Python 'setuptools'
==========================================================


The required Python package setuptools could not be installed.


If the above does not help you resolve the issue, please contact the
Rally team by sending an email to the OpenStack mailing list
openstack-dev@lists.openstack.org. Include the full output of this
script to help us identifying the problem.

Aborting installation!
```

