### PR TITLE
Backport fixes from upstream needed to run tests

### DIFF
--- a/tests/unit/deployment/serverprovider/providers/test_openstack.py
+++ b/tests/unit/deployment/serverprovider/providers/test_openstack.py
@@ -17,9 +17,9 @@
 
 import textwrap
 
+import fixtures
 import jsonschema
 import mock
-from oslotest import mockpatch
 
 from rally.deployment.serverprovider.providers import openstack as provider
 from rally import exceptions
@@ -43,7 +43,7 @@ class OpenStackProviderTestCase(test.TestCase):
 
     def setUp(self):
         super(OpenStackProviderTestCase, self).setUp()
-        self.useFixture(mockpatch.Patch(
+        self.useFixture(fixtures.MockPatch(
             "rally.deployment.serverprovider.provider.ResourceManager"))
 
     def _get_valid_config(self):

--- a/tests/unit/deployment/serverprovider/providers/test_virsh.py
+++ b/tests/unit/deployment/serverprovider/providers/test_virsh.py
@@ -15,10 +15,10 @@
 
 import os
 
+import fixtures
 import jsonschema
 import mock
 import netaddr
-from oslotest import mockpatch
 
 from rally.deployment.serverprovider.providers import virsh
 from tests.unit import test
@@ -36,7 +36,7 @@ class VirshProviderTestCase(test.TestCase):
             "template_password": "password",
         }
         self.provider = virsh.VirshProvider(self.deployment, self.config)
-        self.useFixture(mockpatch.PatchObject(self.provider, "resources"))
+        self.useFixture(fixtures.MockPatchObject(self.provider, "resources"))
 
     @mock.patch(
         "rally.deployment.serverprovider.providers.virsh.netaddr.IPAddress")

--- a/tests/unit/plugins/openstack/test_scenario.py
+++ b/tests/unit/plugins/openstack/test_scenario.py
@@ -12,8 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import fixtures
 import mock
-from oslotest import mockpatch
 
 from rally.plugins.openstack import scenario as base_scenario
 from tests.unit import test
@@ -22,8 +22,7 @@ from tests.unit import test
 class OpenStackScenarioTestCase(test.TestCase):
     def setUp(self):
         super(OpenStackScenarioTestCase, self).setUp()
-        self.osclients = mockpatch.Patch(
-            "rally.osclients.Clients")
+        self.osclients = fixtures.MockPatch("rally.osclients.Clients")
         self.useFixture(self.osclients)
         self.context = test.get_test_context()
         self.context.update({"foo": "bar"})

--- a/tests/unit/test.py
+++ b/tests/unit/test.py
@@ -13,13 +13,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import fixtures
 import os
 import uuid
 
 import mock
 from oslo_config import fixture
 from oslotest import base
-from oslotest import mockpatch
 
 from rally.common import db
 from rally import plugins
@@ -114,15 +114,15 @@ class ScenarioTestCase(TestCase):
     def setUp(self):
         super(ScenarioTestCase, self).setUp()
         if self.patch_benchmark_utils:
-            self.mock_resource_is = mockpatch.Patch(
+            self.mock_resource_is = fixtures.MockPatch(
                 self.benchmark_utils + ".resource_is")
-            self.mock_get_from_manager = mockpatch.Patch(
+            self.mock_get_from_manager = fixtures.MockPatch(
                 self.benchmark_utils + ".get_from_manager")
-            self.mock_wait_for = mockpatch.Patch(
+            self.mock_wait_for = fixtures.MockPatch(
                 self.benchmark_utils + ".wait_for")
-            self.mock_wait_for_delete = mockpatch.Patch(
+            self.mock_wait_for_delete = fixtures.MockPatch(
                 self.benchmark_utils + ".wait_for_delete")
-            self.mock_wait_for_status = mockpatch.Patch(
+            self.mock_wait_for_status = fixtures.MockPatch(
                 self.benchmark_utils + ".wait_for_status")
             self.useFixture(self.mock_resource_is)
             self.useFixture(self.mock_get_from_manager)
@@ -130,7 +130,7 @@ class ScenarioTestCase(TestCase):
             self.useFixture(self.mock_wait_for_delete)
             self.useFixture(self.mock_wait_for_status)
 
-        self.mock_sleep = mockpatch.Patch("time.sleep")
+        self.mock_sleep = fixtures.MockPatch("time.sleep")
         self.useFixture(self.mock_sleep)
 
         self._clients = {}


### PR DESCRIPTION
Pick up a change that switches tests to fixtures so that they can be run again.

Patch also the code that has been removed upstream before the switch.

This will enable us to add tests for rally-ovs plugin. PoC of a test for rally-ovs:

https://github.com/jsitnicki/rally/commit/7d8d9151c3008bd723c8d21653f90504a4a0b222