### PR TITLE
SSH: Add destructor

### DIFF
--- a/rally/common/sshutils.py
+++ b/rally/common/sshutils.py
@@ -103,6 +103,10 @@ class SSH(object):
         self.key_filename = key_filename
         self._client = False
 
+    def __del__(self):
+        if self._client:
+            self.close()
+
     def _get_pkey(self, key):
         if isinstance(key, six.string_types):
             key = six.moves.StringIO(key)


### PR DESCRIPTION
This automatically will close SSH connections when the SSH session goes
out of scope.